### PR TITLE
Remove duplicated CONFIG_AP_MODE check.

### DIFF
--- a/include/rtw_ap.h
+++ b/include/rtw_ap.h
@@ -47,7 +47,6 @@ void rtw_set_macaddr_acl(struct adapter *padapter, int mode);
 int rtw_acl_add_sta(struct adapter *padapter, u8 *addr);
 int rtw_acl_remove_sta(struct adapter *padapter, u8 *addr);
 
-#ifdef CONFIG_AP_MODE
 void associated_clients_update(struct adapter *padapter, u8 updated);
 void bss_cap_update_on_sta_join(struct adapter *padapter, struct sta_info *psta);
 u8 bss_cap_update_on_sta_leave(struct adapter *padapter, struct sta_info *psta);
@@ -59,7 +58,6 @@ int rtw_sta_flush(struct adapter *padapter);
 int rtw_ap_inform_ch_switch(struct adapter *padapter, u8 new_ch, u8 ch_offset);
 void start_ap_mode(struct adapter *padapter);
 void stop_ap_mode(struct adapter *padapter);
-#endif
 #endif /* end of CONFIG_AP_MODE */
 
 #endif


### PR DESCRIPTION
The check for AP_MODE config is duplicated so it can be removed.
