### PR TITLE
Move vars from rtw_recv.h to rtw_recv.c in order to prevent unused vars warnings when including rtw_recv.h

### DIFF
--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -29,6 +29,25 @@
 #include <usb_ops.h>
 #include <wifi.h>
 
+static u8 SNAP_ETH_TYPE_IPX[2] = {0x81, 0x37};
+
+static u8 SNAP_ETH_TYPE_APPLETALK_AARP[2] = {0x80, 0xf3};
+static u8 SNAP_ETH_TYPE_APPLETALK_DDP[2] = {0x80, 0x9b};
+static u8 SNAP_ETH_TYPE_TDLS[2] = {0x89, 0x0d};
+/*  Datagram Delivery Protocol */
+static u8 SNAP_HDR_APPLETALK_DDP[3] = {0x08, 0x00, 0x07};
+
+static u8 oui_8021h[] = {0x00, 0x00, 0xf8};
+static u8 oui_rfc1042[] = {0x00, 0x00, 0x00};
+
+static u8 rtw_rfc1042_header[] = {
+	0xaa, 0xaa, 0x03, 0x00, 0x00, 0x00
+};
+/* Bridge-Tunnel header (for EtherTypes ETH_P_AARP and ETH_P_IPX) */
+static u8 rtw_bridge_tunnel_header[] = {
+	0xaa, 0xaa, 0x03, 0x00, 0x00, 0xf8
+};
+
 void rtw_signal_stat_timer_hdl(RTW_TIMER_HDL_ARGS);
 
 void _rtw_init_sta_recv_priv(struct sta_recv_priv *psta_recvpriv)

--- a/include/rtw_recv.h
+++ b/include/rtw_recv.h
@@ -35,25 +35,7 @@
 
 #define SNAP_SIZE sizeof(struct ieee80211_snap_hdr)
 
-static u8 SNAP_ETH_TYPE_IPX[2] = {0x81, 0x37};
-
-static u8 SNAP_ETH_TYPE_APPLETALK_AARP[2] = {0x80, 0xf3};
-static u8 SNAP_ETH_TYPE_APPLETALK_DDP[2] = {0x80, 0x9b};
-static u8 SNAP_ETH_TYPE_TDLS[2] = {0x89, 0x0d};
-/*  Datagram Delivery Protocol */
-static u8 SNAP_HDR_APPLETALK_DDP[3] = {0x08, 0x00, 0x07};
-
-static u8 oui_8021h[] = {0x00, 0x00, 0xf8};
-static u8 oui_rfc1042[] = {0x00, 0x00, 0x00};
-
 #define MAX_SUBFRAME_COUNT	64
-static u8 rtw_rfc1042_header[] = {
-	0xaa, 0xaa, 0x03, 0x00, 0x00, 0x00
-};
-/* Bridge-Tunnel header (for EtherTypes ETH_P_AARP and ETH_P_IPX) */
-static u8 rtw_bridge_tunnel_header[] = {
-	0xaa, 0xaa, 0x03, 0x00, 0x00, 0xf8
-};
 
 /* for Rx reordering buffer control */
 struct recv_reorder_ctrl {


### PR DESCRIPTION
Note that "SNAP_ETH_TYPE_APPLETALK_DDP", "SNAP_ETH_TYPE_TDLS", "SNAP_HDR_APPLETALK_DDP", "oui_8021h" and "oui_rfc1042" are still unused and can be commented out.
