### PR TITLE
rtl8188eu: Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,10 +149,11 @@ strip:
 	$(CROSS_COMPILE)strip 8188eu.ko --strip-unneeded
 
 install:
-	install -p -m 644 8188eu.ko  $(MODDESTDIR)
+	install -p -D -m 644 8188eu.ko $(MODDESTDIR)/8188eu.ko
 	/sbin/depmod -a ${KVER}
-	mkdir -p /lib/firmware/rtlwifi
-	cp rtl8188eufw.bin /lib/firmware/rtlwifi/.
+
+install_firmware:
+	install -p -D -m 644 rtl8188eufw.bin /lib/firmware/rtlwifi/rtl8188eufw.bin
 
 uninstall:
 	rm -f $(MODDESTDIR)/8188eu.ko

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ consult your distro.
 
 > sudo make install
 
+> sudo make install_firmware
+
 Submitting Issues
 ---------
 
@@ -24,5 +26,5 @@ Frequently asked Questions
 ---------
 
 ### The network manager says: "Device is not ready"!
-Make sure you copied the firmware (rtl8188eufw.bin) to /lib/firmware/rtlwifi/
+Make sure you ran `sudo make install_firmware`
 


### PR DESCRIPTION
- install target should create destination directory, if not found.
- some people don't want to install the firmware binary by default, e.g.
  someone who already installed the linux-firmware package from its
  Linux distribution.
