### PR TITLE
Updated Makefile to support armv7l

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ ifeq ($(CONFIG_WOWLAN), y)
 EXTRA_CFLAGS += -DCONFIG_WOWLAN
 endif
 
-SUBARCH := $(shell uname -m | sed -e s/i.86/i386/ | sed -e s/ppc/powerpc/ | sed -e s/armv6l/arm/)
+SUBARCH := $(shell uname -m | sed -e s/i.86/i386/ | sed -e s/ppc/powerpc/ | sed -e s/armv.l/arm/)
 
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=


### PR DESCRIPTION
Compiling on an armv7l was broken due to SUBARCH not matching the architecture.
