### PR TITLE
Delete unnecessary slash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
 KVER  := $(shell uname -r)
 KSRC := /lib/modules/$(KVER)/build
-MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless
 INSTALL_PREFIX :=
 
 ifneq ($(KERNELRELEASE),)


### PR DESCRIPTION
Variable is used later as `$(MODDESTDIR)/`
