### PR TITLE
 Adding Support for Dlink 123 11n Adapter

### DIFF
--- a/os_dep/usb_intf.c
+++ b/os_dep/usb_intf.c
@@ -55,6 +55,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	/****** 8188EUS ********/
 	{USB_DEVICE(0x07B8, 0x8179)}, /* Abocom - Abocom */
 	{USB_DEVICE(0x2001, 0x330F)}, /* DLink DWA-125 REV D1 */
+        {USB_DEVICE(0x2001, 0x3310)}, /* Dlink DWA-123 REV D1 */
 	{}	/* Terminating entry */
 };
 


### PR DESCRIPTION
1. Checked that this driver works with the given version on kernel 3.11.10-7-desktop on my computer
2. Also, hwinfo --usb shows the following output for this driver. Please
   find the output :

10: USB 00.0: 0200 Ethernet controller
  [Created at usb.122]
  Unique ID: R_O4.dPfoed7O7sA
  Parent ID: pBe4.2DFUsyrieMD
  SysFS ID: /devices/pci0000:00/0000:00:14.0/usb2/2-6/2-6:1.0
  SysFS BusID: 2-6:1.0
  Hardware Class: network
  Model: "D-Link DWA-123 11n Adapter"
  Hotplug: USB
  Vendor: usb 0x2001 "D-Link"
  Device: usb 0x3310 "DWA-123 11n Adapter"
  Serial ID: "D8FEE3575902"
  Driver: "r8188eu"
  Driver Modules: "8188eu"
  Device File: wlp0s20u6
  Speed: 480 Mbps
  HW Address: d8:fe:e3:57:59:02
  Link detected: yes
  Module Alias: "usb:v2001p3310d0000dc00dsc00dp00icFFiscFFipFFin00"
  Driver Info #0:
    Driver Status: 8188eu is active
    Driver Activation Cmd: "modprobe 8188eu"
  Config Status: cfg=new, avail=yes, need=no, active=unknown
  Attached to: #6 (Hub)
