### PR TITLE
Adding support for GO-USB-N150 REV B1

### DIFF
--- a/os_dep/usb_intf.c
+++ b/os_dep/usb_intf.c
@@ -55,6 +55,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	/****** 8188EUS ********/
 	{USB_DEVICE(0x07B8, 0x8179)}, /* Abocom - Abocom */
 	{USB_DEVICE(0x2001, 0x330F)}, /* DLink DWA-125 REV D1 */
+	{USB_DEVICE(0x2001, 0x3311)}, /* DLink GO-USB-N150 REV B1 */
 	{}	/* Terminating entry */
 };
 


### PR DESCRIPTION
hwinfo --usb

06: USB 00.0: 0000 Unclassified device
  [Created at usb.122]
  Unique ID: ADDn.YV8Axhc1AvB
  Parent ID: k4bc.YdoZZg0c8i6
  SysFS ID: /devices/pci0000:00/0000:00:12.2/usb1/1-1/1-1:1.0
  SysFS BusID: 1-1:1.0
  Hardware Class: unknown
  Model: "D-Link GO-USB-N150 N Adapter"
  Hotplug: USB
  Vendor: usb 0x2001 "D-Link"
  Device: usb 0x3311 "GO-USB-N150 N Adapter"
  Serial ID: "D8FEE3571CE3"
  Driver: "r8188eu"
  Driver Modules: "8188eu"
  Device File: wlan1
  Speed: 480 Mbps
  HW Address: d8:fe:e3:57:1c:e3
  Link detected: yes
  Module Alias: "usb:v2001p3311d0000dc00dsc00dp00icFFiscFFipFFin00"
  Driver Info #0:
    Driver Status: 8188eu is active
    Driver Activation Cmd: "modprobe 8188eu"
  Config Status: cfg=new, avail=yes, need=no, active=unknown
  Attached to: #5 (Hub)
