### PR TITLE
quote parameters sent to sub-make call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ export CONFIG_RTL8188EU = m
 all: modules
 
 modules:
-	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules
+	$(MAKE) ARCH="$(ARCH)" CROSS_COMPILE="$(CROSS_COMPILE)" -C "$(KSRC)" M="$(shell pwd)"  modules
 
 strip:
 	$(CROSS_COMPILE)strip 8188eu.ko --strip-unneeded


### PR DESCRIPTION
Sometimes, one or several of these variables are made of several words so we need to enclose them in quotes so that they are correctly passed to make.
