### PR TITLE
Fix function arguments to match ndo_select_queue in 3.13 headers.

### DIFF
--- a/os_dep/os_intfs.c
+++ b/os_dep/os_intfs.c
@@ -655,8 +655,9 @@ static unsigned int rtw_classify8021d(struct sk_buff *skb)
 }
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0))
 			    ,void *unused
+                            ,select_queue_fallback_t fallback
 #endif
 )
 {


### PR DESCRIPTION
Required to compile without warning on 3.13.0 kernel.
