### PR TITLE
luca/makefile-improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,10 @@ strip:
 modules_install:
 	$(MAKE) -C $(KSRC) M=`pwd` modules_install
 
+firmware_install:
+	install -D -m 644 rtl8188eufw.bin \
+		$(INSTALL_MOD_PATH)/lib/firmware/rtlwifi/rtl8188eufw.bin
+
 install:
 	install -p -m 644 8188eu.ko  $(MODDESTDIR)
 	@if [ -a /lib/modules/$(KVER)/kernel/drivers/staging/rtl8188eu/r8188eu.ko ] ; then modprobe -r r8188eu; fi;

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,6 @@ install: firmware_install
 	install -p -m 644 8188eu.ko  $(MODDESTDIR)
 	@if [ -a /lib/modules/$(KVER)/kernel/drivers/staging/rtl8188eu/r8188eu.ko ] ; then modprobe -r r8188eu; fi;
 	@echo "blacklist r8188eu" > /etc/modprobe.d/50-8188eu.conf
-	cp rtl8188eufw.bin /lib/firmware/.
 	/sbin/depmod -a ${KVER}
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,9 @@ modules:
 strip:
 	$(CROSS_COMPILE)strip 8188eu.ko --strip-unneeded
 
+modules_install:
+	$(MAKE) -C $(KSRC) M=`pwd` modules_install
+
 install:
 	install -p -m 644 8188eu.ko  $(MODDESTDIR)
 	@if [ -a /lib/modules/$(KVER)/kernel/drivers/staging/rtl8188eu/r8188eu.ko ] ; then modprobe -r r8188eu; fi;

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ export CONFIG_RTL8188EU = m
 all: modules
 
 modules:
-	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules
+	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE="$(CROSS_COMPILE)" -C $(KSRC) M=$(shell pwd)  modules
 
 strip:
 	$(CROSS_COMPILE)strip 8188eu.ko --strip-unneeded

--- a/Makefile
+++ b/Makefile
@@ -156,14 +156,12 @@ firmware_install:
 	install -D -m 644 rtl8188eufw.bin \
 		$(INSTALL_MOD_PATH)/lib/firmware/rtlwifi/rtl8188eufw.bin
 
-install:
+install: firmware_install
 	install -p -m 644 8188eu.ko  $(MODDESTDIR)
 	@if [ -a /lib/modules/$(KVER)/kernel/drivers/staging/rtl8188eu/r8188eu.ko ] ; then modprobe -r r8188eu; fi;
 	@echo "blacklist r8188eu" > /etc/modprobe.d/50-8188eu.conf
 	cp rtl8188eufw.bin /lib/firmware/.
 	/sbin/depmod -a ${KVER}
-	mkdir -p /lib/firmware/rtlwifi
-	cp -n rtl8188eufw.bin /lib/firmware/rtlwifi/.
 
 uninstall:
 	rm -f $(MODDESTDIR)/8188eu.ko


### PR DESCRIPTION
Dear Larry,

here are a few cleanups and additions to Makefile.

I'm integrating rtl8188eu in Buildroot, for use on embedded systems with old kernels that have no mainline driver. But the 'install' target is specifically tailored for native building and installing, so I had to add a new 'modules_install' target that nicely integrate with a build system.

Patches are roughly in order from those that I believe to be "obviously OK" to those for which you might have comments, change requests or simply rejects.
