### PR TITLE
Add support for the Rosewill RNX-N150NUB USB NIC

### DIFF
--- a/os_dep/usb_intf.c
+++ b/os_dep/usb_intf.c
@@ -58,6 +58,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x2001, 0x3311)}, /* DLink GO-USB-N150 REV B1 */
 	{USB_DEVICE(0x056E, 0x4008)}, /* Elecom WDC-150SU2M */
 	{USB_DEVICE(0x2357, 0x010c)}, /* TP-Link TL-WN722N v2 */
+	{USB_DEVICE(USB_VENDER_ID_REALTEK, 0xffef)}, /* Rosewill RNX-N150NUB */
 	{}	/* Terminating entry */
 };
 


### PR DESCRIPTION
`ideal for raspberry pi` my ass

I'll probably try to get this one on the official kernel driver, but I'll add it here for now.

EDIT: Sent the patch to gregkh@linuxfoundation.org. I think I did it right.