### PR TITLE
Add subarch modifier for ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ ifeq ($(CONFIG_WOWLAN), y)
 EXTRA_CFLAGS += -DCONFIG_WOWLAN
 endif
 
-SUBARCH := $(shell uname -m | sed -e s/i.86/i386/ | sed -e s/ppc/powerpc/ | sed -e s/armv.l/arm/)
+SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
 
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=


### PR DESCRIPTION
Kernel is compiled as 'aarch64', but the kernel arch directory is 'arm64'.

The multiple calls to sed for modifying the output of 'uname -m' is now
consolidated into a single call with multiple commands.