### PR TITLE
Fix build for kernel 4.13 and later from quickreflex patch

### DIFF
--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -1830,7 +1830,7 @@ static void traffic_status_watchdog(struct adapter *padapter)
 			      pmlmepriv->LinkDetectInfo.NumTxOkInPeriod) > 8 ) ||
 			    (pmlmepriv->LinkDetectInfo.NumRxUnicastOkInPeriod > 2))
 			bEnterPS = false;
-		else
+			else
 			bEnterPS = true;
 
 			/*  LeisurePS only work in infra mode. */

--- a/core/rtw_iol.c
+++ b/core/rtw_iol.c
@@ -236,7 +236,8 @@ void rtw_IOL_cmd_buf_dump(struct adapter *Adapter, int buf_len, u8 *pbuf)
 	for (i =0;i< buf_len;i++) {
 		printk("%02x-",*(pbuf+i));
 
-		if (j%32 == 0) printk("\n");j++;
+		if (j%32 == 0) printk("\n");
+		j++;
 	}
 	printk("\n");
 	printk("============= ioreg_cmd len = %d ===============\n", buf_len);

--- a/core/rtw_pwrctrl.c
+++ b/core/rtw_pwrctrl.c
@@ -52,7 +52,7 @@ void _ips_enter(struct adapter * padapter)
 	if (rf_off == pwrpriv->change_rfpwrstate )
 	{
 		pwrpriv->bpower_saving = true;
-		DBG_88E_LEVEL(_drv_always_, "nolinked power save enter\n");
+		DBG_88E_LEVEL(_drv_info_, "nolinked power save enter\n");
 
 		if (pwrpriv->ips_mode == IPS_LEVEL_2)
 			pwrpriv->bkeepfwalive = true;
@@ -88,7 +88,7 @@ int _ips_leave(struct adapter * padapter)
 		if ((result = rtw_ips_pwr_up(padapter)) == _SUCCESS) {
 			pwrpriv->rf_pwrstate = rf_on;
 		}
-		DBG_88E_LEVEL(_drv_always_, "nolinked power save leave\n");
+		DBG_88E_LEVEL(_drv_info_, "nolinked power save leave\n");
 
 		DBG_88E("==> ips_leave.....LED(0x%08x)...\n", rtw_read32(padapter, 0x4c));
 		pwrpriv->bips_processing = false;

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -2003,7 +2003,7 @@ void update_bmc_sta_support_rate(struct adapter *padapter, u32 mac_id)
 	}
 	else
 	{
-		memcpy((pmlmeinfo->FW_sta_info[mac_id].SupportedRates), rtw_basic_rate_ofdm, 4);
+		memcpy((pmlmeinfo->FW_sta_info[mac_id].SupportedRates), rtw_basic_rate_ofdm, 3);
 	}
 }
 

--- a/hal/HalPhyRf_8188e.c
+++ b/hal/HalPhyRf_8188e.c
@@ -1251,7 +1251,7 @@ phy_IQCalibrate_8188E(
 #endif
 	if ( *(pDM_Odm->mp_mode) == 1)
 		retryCount = 9;
-else
+	else
 	retryCount = 2;
 	/*  Note: IQ calibration must be performed after loading */
 	/* 		PHY_REG.txt , and radio_a, radio_b.txt */

--- a/hal/rtl8188e_hal_init.c
+++ b/hal/rtl8188e_hal_init.c
@@ -406,7 +406,9 @@ static s32 iol_read_efuse(
 s32 rtl8188e_iol_efuse_patch(struct adapter *padapter)
 {
 	s32	result = _SUCCESS;
-	printk("==> %s\n",__FUNCTION__);
+
+	/* deleted because it prints every 7s when not associated */
+	/* printk("==> %s\n",__FUNCTION__); */
 
 	if (rtw_IOL_applied(padapter)) {
 		iol_mode_enable(padapter, 1);

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -22,6 +22,10 @@
 
 #include <drv_conf.h>
 #include <basic_types.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+    #include <linux/sched/signal.h>
+#endif
 
 #define _FAIL		0
 #define _SUCCESS	1


### PR DESCRIPTION
PR for branch v4.1.8_9499 that implements quickreflex's patch to bring this driver up to kernel version 4.13.y (see #232), plus additional changes to:
1) Fix a stack framesize issue
2) suppress some power save messages
3) suppress a patch message.