### PR TITLE
Add modules_install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,9 @@ install:
 	mkdir -p /lib/firmware/rtlwifi
 	cp rtl8188eufw.bin /lib/firmware/rtlwifi/.
 
+modules_install:
+	$(MAKE) -C $(KSRC) M=$(shell pwd) modules_install
+
 uninstall:
 	rm -f $(MODDESTDIR)/8188eu.ko
 	/sbin/depmod -a ${KVER}


### PR DESCRIPTION
This target is used by yocto build system for building kernel modules.