### PR TITLE
Added yocto bitbake recipe for V4.1.8 9499

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ SUBARCH := $(shell uname -m | sed -e s/i.86/i386/ | sed -e s/ppc/powerpc/ | sed 
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
 KVER  := $(shell uname -r)
-KSRC := /lib/modules/$(KVER)/build
+KERNEL_SRC ?= /lib/modules/$(KVER)/build
 MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 INSTALL_PREFIX :=
 
@@ -150,7 +150,10 @@ export CONFIG_RTL8188EU = m
 all: modules
 
 modules:
-	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules
+	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KERNEL_SRC) M=$(shell pwd) modules
+
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(shell pwd) modules_install
 
 strip:
 	$(CROSS_COMPILE)strip 8188eu.ko --strip-unneeded

--- a/meta-yocto/recipes-connectivity/rtl8188eu/rtl8188eu_4.1.8.bb
+++ b/meta-yocto/recipes-connectivity/rtl8188eu/rtl8188eu_4.1.8.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Realtek rtl8188eu driver"
+DESCRIPTION = "lwfinger's rtl8188eu driver that enables AP mode support"
+AUTHOR = "Yevhen Fastiuk <yevfast@gmail.com>"
+SECTION = "Connectivity"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
+
+inherit module
+
+S = "${WORKDIR}/git"
+
+SRCREV = "${AUTOREV}"
+SRC_URI = "git://github.com/lwfinger/rtl8188eu.git;branch=v4.1.8_9499"
+
+RTLWIFI = "${base_libdir}/firmware/rtlwifi"
+
+do_install_append() {
+	install -d ${D}/${RTLWIFI}
+	install -m 0755 ${S}/rtl8188eufw.bin ${D}/${RTLWIFI}/
+}
+
+FILES_${PN} += "${RTLWIFI}/*"


### PR DESCRIPTION
Dear Larry,

Fixed targets for yocto build system and added bitbake recipe to build driver inside the Yocto build system.

PS: Sorry for deleted previous PR. I need to have V4.1.8 9499 branch on my side.