### PR TITLE
rtl8188eu: Add rtw_led_enable module parameter

### DIFF
--- a/core/rtw_led.c
+++ b/core/rtw_led.c
@@ -1652,12 +1652,17 @@ void BlinkHandler(struct LED_871x *pLed)
 void LedControl8188eu(struct adapter *padapter, enum LED_CTL_MODE LedAction)
 {
 	struct led_priv *ledpriv = &(padapter->ledpriv);
+	struct registry_priv *registry_par;
 
        if ((padapter->bSurpriseRemoved) || (padapter->bDriverStopped) ||
 	   (!padapter->hw_init_completed))
 		return;
 
 	if (!ledpriv->bRegUseLed)
+		return;
+
+	registry_par = &padapter->registrypriv;
+	if (!registry_par->led_enable)
 		return;
 
 	if ((padapter->pwrctrlpriv.rf_pwrstate != rf_on &&

--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -114,6 +114,8 @@ struct registry_priv {
 	u8	uapsd_acvi_en;
 	u8	uapsd_acvo_en;
 
+	u8	led_enable;
+
 	struct wlan_bssid_ex    dev_network;
 
 	u8	ht_enable;

--- a/os_dep/os_intfs.c
+++ b/os_dep/os_intfs.c
@@ -86,6 +86,8 @@ static int rtw_uapsd_acbe_en;
 static int rtw_uapsd_acvi_en;
 static int rtw_uapsd_acvo_en;
 
+static int rtw_led_enable = 1;
+
 int rtw_ht_enable = 1;
 int rtw_cbw40_enable = 3; /*  0 :disable, bit(0): enable 2.4g, bit(1): enable 5g */
 int rtw_ampdu_enable = 1;/* for enable tx_ampdu */
@@ -137,6 +139,7 @@ module_param(rtw_wmm_enable, int, 0644);
 module_param(rtw_vrtl_carrier_sense, int, 0644);
 module_param(rtw_vcs_type, int, 0644);
 module_param(rtw_busy_thresh, int, 0644);
+module_param(rtw_led_enable, int, 0644);
 module_param(rtw_ht_enable, int, 0644);
 module_param(rtw_cbw40_enable, int, 0644);
 module_param(rtw_ampdu_enable, int, 0644);
@@ -561,6 +564,8 @@ static uint loadparam(struct adapter *padapter,  struct  net_device *pnetdev)
 	registry_par->uapsd_acbe_en = (u8)rtw_uapsd_acbe_en;
 	registry_par->uapsd_acvi_en = (u8)rtw_uapsd_acvi_en;
 	registry_par->uapsd_acvo_en = (u8)rtw_uapsd_acvo_en;
+
+	registry_par->led_enable = (u8)rtw_led_enable;
 
 	registry_par->ht_enable = (u8)rtw_ht_enable;
 	registry_par->cbw40_enable = (u8)rtw_cbw40_enable;


### PR DESCRIPTION
Make it possible to disable the LED, as it can be pretty annoying
depending on where it's located.

Is there a more generic way of doing this? I have a similar change for the upstream staging driver, if it's acceptable.