### PR TITLE
Fix the powerpc kernel header path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ifeq ($(CONFIG_WOWLAN), y)
 EXTRA_CFLAGS += -DCONFIG_WOWLAN
 endif
 
-SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
+SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc.*/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
 
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=


### PR DESCRIPTION
I ran into compiling issue on my Raptor Blackbird /w POWER9 V2 8-core 3.8Ghz running Fedora 32 (rawhide):

```
$ uname -m
ppc64le
$ make all
make ARCH=powerpc64le CROSS_COMPILE= -C /lib/modules/5.4.15-200.fc31.ppc64le/build M=/home/tle/rtl8188eu  modules
make[1]: Entering directory '/usr/src/kernels/5.4.15-200.fc31.ppc64le'
Makefile:653: arch/powerpc64le/Makefile: No such file or directory
make[1]: *** No rule to make target 'arch/powerpc64le/Makefile'.  Stop.
make[1]: Leaving directory '/usr/src/kernels/5.4.15-200.fc31.ppc64le'
make: *** [Makefile:155: modules] Error 2
```

Because ppc64le headers reside in `arch/powerpc` instead of `arch/powerpc64le`. 

I could confirm the driver is successfully compiled after that change:

```
$ make all
make ARCH=powerpc CROSS_COMPILE= -C /lib/modules/5.4.15-200.fc31.ppc64le/build M=/home/tle/rtl8188eu  modules
make[1]: Entering directory '/usr/src/kernels/5.4.15-200.fc31.ppc64le'
  CC [M]  /home/tle/rtl8188eu/core/rtw_ap.o
  ...
  LD [M]  /home/tle/rtl8188eu/8188eu.o
  Building modules, stage 2.
  MODPOST 1 modules
  CC [M]  /home/tle/rtl8188eu/8188eu.mod.o
  LD [M]  /home/tle/rtl8188eu/8188eu.ko
make[1]: Leaving directory '/usr/src/kernels/5.4.15-200.fc31.ppc64le'
```
