### PR TITLE
Add VID&PID for Asus N10 Nano B1

### DIFF
--- a/os_dep/usb_intf.c
+++ b/os_dep/usb_intf.c
@@ -61,6 +61,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x2357, 0x010c)}, /* TP-Link TL-WN722N v2 */
 	{USB_DEVICE(0x2357, 0x0111)}, /* TP-Link TL-WN727N v5.21 */
 	{USB_DEVICE(0x2C4E, 0x0102)}, /* MERCUSYS MW150US v2 */
+	{USB_DEVICE(0x0B05, 0x18F0)}, /* ASUS USB-N10 Nano B1 */
 	{}	/* Terminating entry */
 };
 


### PR DESCRIPTION
My version of Asus Nano N10 works only with this driver. 
But works well with it.

```
Bus 001 Device 004: ID 0b05:18f0 ASUSTek Computer, Inc.
```

```
T:  Bus=01 Lev=02 Prnt=02 Port=02 Cnt=02 Dev#=  4 Spd=480 MxCh= 0
D:  Ver= 2.00 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs=  1
P:  Vendor=0b05 ProdID=18f0 Rev=00.00
S:  Manufacturer=Realtek
S:  Product=802.11n NIC
S:  SerialNumber=A85E4563E718
C:  #Ifs= 1 Cfg#= 1 Atr=a0 MxPwr=500mA
I:  If#=0x0 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=r8188eu
```