### PR TITLE
[network-manager] Add how to address no SSID scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ Frequently asked Questions
 ### The network manager says: "Device is not ready"!
 Make sure you copied the firmware (rtl8188eufw.bin) to /lib/firmware/rtlwifi/
 
+### NetworkManager does not list SSID
+NetworkManager changes the Wi-Fi MAC address during scanning to improve privacy but this adapter does not support it. To adress this issue, please create `/etc/NetworkManager/conf.d/80-wifi.conf` with content:
+
+```
+[device]
+wifi.scan-rand-mac-address=no
+```
+
+and run `systemctl restart NetworkManager`


### PR DESCRIPTION
The issue was reported upstream at https://gitlab.freedesktop.org/NetworkManager/NetworkManager/issues/158

## Before

![Screenshot from 2020-04-06 19-08-25](https://user-images.githubusercontent.com/135605/78732937-59102e80-7987-11ea-95f6-d2a88b66fde2.png)


## After

![Screenshot from 2020-04-08 10-48-09](https://user-images.githubusercontent.com/135605/78732934-557ca780-7987-11ea-9aa8-13bb5cdbc164.png)
