### PR TITLE
Remove no-op build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,6 @@ EXTRA_CFLAGS += -Wno-unused-function
 EXTRA_CFLAGS += -Wno-unused
 EXTRA_CFLAGS += -Wno-uninitialized
 
-GCC_VER_49 := $(shell echo `$(CC) -dumpversion | cut -f1-2 -d.` \>= 4.9 | bc )
-ifeq ($(GCC_VER_49),1)
-EXTRA_CFLAGS += -Wno-date-time	# Fix compile error && warning on gcc 4.9 and later
-endif
-
 EXTRA_CFLAGS += -I$(src)/include
 EXTRA_CFLAGS += -I$(src)/hal/phydm
 


### PR DESCRIPTION
Since https://github.com/lwfinger/rtl8188eu/commit/af9277ea3b29c2d5c3929ff504c24fbf83eb2ffd, there is no `__DATE__`, `__TIME__` or `__TIMESTAMP__` nowhere in code, so `-Wno-date-time` has no effect.

On the other hand removing these lines from Makefile fixes an error message when `bc` is not installed. 