### PR TITLE
Fix GCC 10 warnings

### DIFF
--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -1262,7 +1262,7 @@ u32 mp_query_psd(PADAPTER pAdapter, u8 *data)
 			psd_data = rtw_GetPSDData(pAdapter, i - psd_pts);
 		else
 			psd_data = rtw_GetPSDData(pAdapter, i);
-		sprintf(data, "%s%x ", data, psd_data);
+		sprintf(data + strlen(data), "%x ", psd_data);
 		i++;
 	}
 

--- a/os_dep/ioctl_linux.c
+++ b/os_dep/ioctl_linux.c
@@ -8298,16 +8298,16 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 
 		sprintf(extra, "\n");
 		for (i = 0; i < cnt; i += 16) {
-			sprintf(extra, "%s0x%02x\t", extra, shift + i);
+			sprintf(extra + strlen(extra), "0x%02x\t", shift + i);
 			for (j = 0; j < 8; j++)
-				sprintf(extra, "%s%02X ", extra, efuse[i + j]);
-			sprintf(extra, "%s\t", extra);
+				sprintf(extra + strlen(extra), "%02X ", efuse[i + j]);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j < 16; j++)
-				sprintf(extra, "%s%02X ", extra, efuse[i + j]);
-			sprintf(extra, "%s\n", extra);
+				sprintf(extra + strlen(extra), "%02X ", efuse[i + j]);
+			sprintf(extra + strlen(extra), "\n");
 		}
 		if ((shift + cnt) < mapLen)
-			sprintf(extra, "%s\t...more (left:%d/%d)\n", extra, mapLen-(shift + cnt), mapLen);
+			sprintf(extra + strlen(extra), "\t...more (left:%d/%d)\n", mapLen-(shift + cnt), mapLen);
 
 	} else if (strcmp(tmp[0], "realmap") == 0) {
 		static u8 order = 0;
@@ -8334,16 +8334,16 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 
 		sprintf(extra, "\n");
 		for (i = 0; i < cnt; i += 16) {
-			sprintf(extra, "%s0x%02x\t", extra, shift + i);
+			sprintf(extra + strlen(extra), "0x%02x\t", shift + i);
 			for (j = 0; j < 8; j++)
-				sprintf(extra, "%s%02X ", extra, efuse[i + j]);
-			sprintf(extra, "%s\t", extra);
+				sprintf(extra + strlen(extra), "%02X ", efuse[i + j]);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j < 16; j++)
-				sprintf(extra, "%s%02X ", extra, efuse[i + j]);
-			sprintf(extra, "%s\n", extra);
+				sprintf(extra + strlen(extra), "%02X ", efuse[i + j]);
+			sprintf(extra + strlen(extra), "\n");
 		}
 		if ((shift + cnt) < mapLen)
-			sprintf(extra, "%s\t...more (left:%d/%d)\n", extra, mapLen-(shift + cnt), mapLen);
+			sprintf(extra + strlen(extra), "\t...more (left:%d/%d)\n", mapLen-(shift + cnt), mapLen);
 	} else if (strcmp(tmp[0], "rmap") == 0) {
 		if ((tmp[1] == NULL) || (tmp[2] == NULL)) {
 			RTW_INFO("%s: rmap Fail!! Parameters error!\n", __func__);
@@ -8380,7 +8380,7 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		*extra = 0;
 		for (i = 0; i < cnts; i++) {
 			/*			RTW_INFO("0x%02x ", data[i]); */
-			sprintf(extra, "%s0x%02X ", extra, data[i]);
+			sprintf(extra + strlen(extra), "0x%02X ", data[i]);
 		}
 		/*		RTW_INFO("}\n"); */
 	} else if (strcmp(tmp[0], "realraw") == 0) {
@@ -8411,16 +8411,16 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 
 		sprintf(extra, "\n");
 		for (i = 0; i < cnt; i += 16) {
-			sprintf(extra, "%s0x%02x\t", extra, shift + i);
+			sprintf(extra + strlen(extra), "0x%02x\t", shift + i);
 			for (j = 0; j < 8; j++)
-				sprintf(extra, "%s%02X ", extra, rawdata[i + j]);
-			sprintf(extra, "%s\t", extra);
+				sprintf(extra + strlen(extra), "%02X ", rawdata[i + j]);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j < 16; j++)
-				sprintf(extra, "%s%02X ", extra, rawdata[i + j]);
-			sprintf(extra, "%s\n", extra);
+				sprintf(extra + strlen(extra), "%02X ", rawdata[i + j]);
+			sprintf(extra + strlen(extra), "\n");
 		}
 		if ((shift + cnt) < mapLen)
-			sprintf(extra, "%s\t...more (left:%d/%d)\n", extra, mapLen-(shift + cnt), mapLen);
+			sprintf(extra + strlen(extra), "\t...more (left:%d/%d)\n", mapLen-(shift + cnt), mapLen);
 
 	} else if (strcmp(tmp[0], "btrealraw") == 0) {
 		static u8 bt_raw_order = 0;
@@ -8458,16 +8458,16 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 
 		sprintf(extra, "\n");
 		for (i = 0; i < cnt; i += 16) {
-			sprintf(extra, "%s0x%02x\t", extra, shift + i);
+			sprintf(extra + strlen(extra), "0x%02x\t", shift + i);
 			for (j = 0; j < 8; j++)
-				sprintf(extra, "%s%02X ", extra, rawdata[i + j]);
-			sprintf(extra, "%s\t", extra);
+				sprintf(extra + strlen(extra), "%02X ", rawdata[i + j]);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j < 16; j++)
-				sprintf(extra, "%s%02X ", extra, rawdata[i + j]);
-			sprintf(extra, "%s\n", extra);
+				sprintf(extra + strlen(extra), "%02X ", rawdata[i + j]);
+			sprintf(extra + strlen(extra), "\n");
 		}
 		if ((shift + cnt) < mapLen)
-			sprintf(extra, "%s\t...more (left:%d/%d)\n", extra, mapLen-(shift + cnt), mapLen);
+			sprintf(extra + strlen(extra), "\t...more (left:%d/%d)\n", mapLen-(shift + cnt), mapLen);
 
 	} else if (strcmp(tmp[0], "mac") == 0) {
 		if (hal_efuse_macaddr_offset(padapter) == -1) {
@@ -8495,10 +8495,10 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		*extra = 0;
 		for (i = 0; i < cnts; i++) {
 			/*			RTW_INFO("%02X", data[i]); */
-			sprintf(extra, "%s%02X", extra, data[i]);
+			sprintf(extra + strlen(extra), "%02X", data[i]);
 			if (i != (cnts - 1)) {
 				/*				RTW_INFO(":"); */
-				sprintf(extra, "%s:", extra);
+				sprintf(extra + strlen(extra), ":");
 			}
 		}
 		/*		RTW_INFO("}\n"); */
@@ -8522,10 +8522,10 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		*extra = 0;
 		for (i = 0; i < cnts; i++) {
 			/*			RTW_INFO("0x%02x", data[i]); */
-			sprintf(extra, "%s0x%02X", extra, data[i]);
+			sprintf(extra + strlen(extra), "0x%02X", data[i]);
 			if (i != (cnts - 1)) {
 				/*				RTW_INFO(","); */
-				sprintf(extra, "%s,", extra);
+				sprintf(extra + strlen(extra), ",");
 			}
 		}
 		/*		RTW_INFO("}\n"); */
@@ -8556,19 +8556,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i = 0; i < 512; i += 16) { /* set 512 because the iwpriv's extra size have limit 0x7FF */
 			/*			RTW_INFO("0x%03x\t", i); */
-			sprintf(extra, "%s0x%03x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%03x\t", i);
 			for (j = 0; j < 8; j++) {
 				/*				RTW_INFO("%02X ", pEfuseHal->BTEfuseInitMap[i+j]); */
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->BTEfuseInitMap[i + j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->BTEfuseInitMap[i + j]);
 			}
 			/*			RTW_INFO("\t"); */
-			sprintf(extra, "%s\t", extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j < 16; j++) {
 				/*				RTW_INFO("%02X ", pEfuseHal->BTEfuseInitMap[i+j]); */
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->BTEfuseInitMap[i + j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->BTEfuseInitMap[i + j]);
 			}
 			/*			RTW_INFO("\n"); */
-			sprintf(extra, "%s\n", extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 		/*		RTW_INFO("\n"); */
 	} else if (strcmp(tmp[0], "btbmap") == 0) {
@@ -8585,19 +8585,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i = 512; i < 1024 ; i += 16) {
 			/*			RTW_INFO("0x%03x\t", i); */
-			sprintf(extra, "%s0x%03x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%03x\t", i);
 			for (j = 0; j < 8; j++) {
 				/*				RTW_INFO("%02X ", data[i+j]); */
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->BTEfuseInitMap[i + j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->BTEfuseInitMap[i + j]);
 			}
 			/*			RTW_INFO("\t"); */
-			sprintf(extra, "%s\t", extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j < 16; j++) {
 				/*				RTW_INFO("%02X ", data[i+j]); */
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->BTEfuseInitMap[i + j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->BTEfuseInitMap[i + j]);
 			}
 			/*			RTW_INFO("\n"); */
-			sprintf(extra, "%s\n", extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 		/*		RTW_INFO("\n"); */
 	} else if (strcmp(tmp[0], "btrmap") == 0) {
@@ -8648,7 +8648,7 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		/*		RTW_INFO("%s: bt efuse data={", __func__); */
 		for (i = 0; i < cnts; i++) {
 			/*			RTW_INFO("0x%02x ", data[i]); */
-			sprintf(extra, "%s 0x%02X ", extra, data[i]);
+			sprintf(extra + strlen(extra), " 0x%02X ", data[i]);
 		}
 		/*		RTW_INFO("}\n"); */
 		RTW_INFO(FUNC_ADPT_FMT ": BT MAC=[%s]\n", FUNC_ADPT_ARG(padapter), extra);
@@ -8657,19 +8657,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i = 0; i < 512; i += 16) {
 			/*			RTW_INFO("0x%03x\t", i); */
-			sprintf(extra, "%s0x%03x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%03x\t", i);
 			for (j = 0; j < 8; j++) {
 				/*				RTW_INFO("%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]); */
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeBTEfuseModifiedMap[i + j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i + j]);
 			}
 			/*			RTW_INFO("\t"); */
-			sprintf(extra, "%s\t", extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j < 16; j++) {
 				/*				RTW_INFO("%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]); */
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeBTEfuseModifiedMap[i + j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i + j]);
 			}
 			/*			RTW_INFO("\n"); */
-			sprintf(extra, "%s\n", extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 		/*		RTW_INFO("\n"); */
 	} else if (strcmp(tmp[0], "btbfake") == 0) {
@@ -8677,19 +8677,19 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		sprintf(extra, "\n");
 		for (i = 512; i < 1024; i += 16) {
 			/*			RTW_INFO("0x%03x\t", i); */
-			sprintf(extra, "%s0x%03x\t", extra, i);
+			sprintf(extra + strlen(extra), "0x%03x\t", i);
 			for (j = 0; j < 8; j++) {
 				/*				RTW_INFO("%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]); */
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeBTEfuseModifiedMap[i + j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i + j]);
 			}
 			/*			RTW_INFO("\t"); */
-			sprintf(extra, "%s\t", extra);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j < 16; j++) {
 				/*				RTW_INFO("%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i+j]); */
-				sprintf(extra, "%s%02X ", extra, pEfuseHal->fakeBTEfuseModifiedMap[i + j]);
+				sprintf(extra + strlen(extra), "%02X ", pEfuseHal->fakeBTEfuseModifiedMap[i + j]);
 			}
 			/*			RTW_INFO("\n"); */
-			sprintf(extra, "%s\n", extra);
+			sprintf(extra + strlen(extra), "\n");
 		}
 		/*		RTW_INFO("\n"); */
 	} else if (strcmp(tmp[0], "wlrfkmap") == 0) {
@@ -8712,16 +8712,16 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 
 		sprintf(extra, "\n");
 		for (i = 0; i < cnt; i += 16) {
-			sprintf(extra, "%s0x%02x\t", extra, shift + i);
+			sprintf(extra + strlen(extra), "0x%02x\t", shift + i);
 			for (j = 0; j < 8; j++)
-				sprintf(extra, "%s%02X ", extra, efuse[i + j]);
-			sprintf(extra, "%s\t", extra);
+				sprintf(extra + strlen(extra), "%02X ", efuse[i + j]);
+			sprintf(extra + strlen(extra), "\t");
 			for (; j < 16; j++)
-				sprintf(extra, "%s%02X ", extra, efuse[i + j]);
-			sprintf(extra, "%s\n", extra);
+				sprintf(extra + strlen(extra), "%02X ", efuse[i + j]);
+			sprintf(extra + strlen(extra), "\n");
 		}
 		if ((shift + cnt) < mapLen)
-			sprintf(extra, "%s\t...more\n", extra);
+			sprintf(extra + strlen(extra), "\t...more\n");
 
 	} else if (strcmp(tmp[0], "wlrfkrmap") == 0) {
 		if ((tmp[1] == NULL) || (tmp[2] == NULL)) {
@@ -8745,7 +8745,7 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		*extra = 0;
 		for (i = 0; i < cnts; i++) {
 			RTW_INFO("wlrfkrmap = 0x%02x\n", pEfuseHal->fakeEfuseModifiedMap[addr + i]);
-			sprintf(extra, "%s0x%02X ", extra, pEfuseHal->fakeEfuseModifiedMap[addr + i]);
+			sprintf(extra + strlen(extra), "0x%02X ", pEfuseHal->fakeEfuseModifiedMap[addr + i]);
 		}
 	} else if (strcmp(tmp[0], "btrfkrmap") == 0) {
 		if ((tmp[1] == NULL) || (tmp[2] == NULL)) {
@@ -8769,7 +8769,7 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 		*extra = 0;
 		for (i = 0; i < cnts; i++) {
 			RTW_INFO("wlrfkrmap = 0x%02x\n", pEfuseHal->fakeBTEfuseModifiedMap[addr + i]);
-			sprintf(extra, "%s0x%02X ", extra, pEfuseHal->fakeBTEfuseModifiedMap[addr + i]);
+			sprintf(extra + strlen(extra), "0x%02X ", pEfuseHal->fakeBTEfuseModifiedMap[addr + i]);
 		}
 	} else if (strcmp(tmp[0], "mask") == 0) {
 		*extra = 0;
@@ -8781,7 +8781,7 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 
 		sprintf(extra, "\n");
 		for (i = 0; i < mask_len; i++)
-			sprintf(extra, "%s0x%02X\n", extra, mask_buf[i]);
+			sprintf(extra + strlen(extra), "0x%02X\n", mask_buf[i]);
 
 	} else
 		sprintf(extra, "Command not found!");

--- a/os_dep/ioctl_mp.c
+++ b/os_dep/ioctl_mp.c
@@ -179,7 +179,7 @@ int rtw_mp_read_reg(struct net_device *dev,
 			if (*pnext != '\0') {
 				/*strtout = simple_strtoul(pnext , &ptmp, 16);*/
 				ret = sscanf(pnext, "%x", &strtout);
-				sprintf(extra, "%s %d" , extra , strtout);
+				sprintf(extra + strlen(extra), " %d", strtout);
 			} else
 				break;
 			pch = pnext;
@@ -211,7 +211,7 @@ int rtw_mp_read_reg(struct net_device *dev,
 			pnext++;
 			if (*pnext != '\0') {
 				ret = sscanf(pnext, "%x", &strtout);
-				sprintf(extra, "%s %d" , extra , strtout);
+				sprintf(extra + strlen(extra), " %d", strtout);
 			} else
 				break;
 			pch = pnext;
@@ -331,7 +331,7 @@ int rtw_mp_read_rf(struct net_device *dev,
 		if (*pnext != '\0') {
 			/*strtou =simple_strtoul(pnext , &ptmp, 16);*/
 			ret = sscanf(pnext, "%x", &strtou);
-			sprintf(extra, "%s %d" , extra , strtou);
+			sprintf(extra + strlen(extra), " %d", strtou);
 		} else
 			break;
 		pch = pnext;
@@ -1401,7 +1401,7 @@ int rtw_mp_pretx_proc(PADAPTER padapter, u8 bStartTest, char *extra)
 			pmp_priv->mode = MP_ON;
 			sprintf(extra, "Stop continuous Tx");
 		} else if (pmp_priv->tx.stop == 1) {
-			sprintf(extra, "%s\nStart continuous DA=ffffffffffff len=1500 count=%u\n", extra, pmp_priv->tx.count);
+			sprintf(extra + strlen(extra), "\nStart continuous DA=ffffffffffff len=1500 count=%u\n", pmp_priv->tx.count);
 			pmp_priv->tx.stop = 0;
 			SetPacketTx(padapter);
 		} else
@@ -1409,26 +1409,26 @@ int rtw_mp_pretx_proc(PADAPTER padapter, u8 bStartTest, char *extra)
 		return 0;
 	case MP_SINGLE_TONE_TX:
 		if (bStartTest != 0)
-			sprintf(extra, "%s\nStart continuous DA=ffffffffffff len=1500\n infinite=yes.", extra);
+			sprintf(extra + strlen(extra), "\nStart continuous DA=ffffffffffff len=1500\n infinite=yes.");
 		SetSingleToneTx(padapter, (u8)bStartTest);
 		break;
 	case MP_CONTINUOUS_TX:
 		if (bStartTest != 0)
-			sprintf(extra, "%s\nStart continuous DA=ffffffffffff len=1500\n infinite=yes.", extra);
+			sprintf(extra + strlen(extra), "\nStart continuous DA=ffffffffffff len=1500\n infinite=yes.");
 		SetContinuousTx(padapter, (u8)bStartTest);
 		break;
 	case MP_CARRIER_SUPPRISSION_TX:
 		if (bStartTest != 0) {
 			if (HwRateToMPTRate(pmp_priv->rateidx) <= MPT_RATE_11M)
-				sprintf(extra, "%s\nStart continuous DA=ffffffffffff len=1500\n infinite=yes.", extra);
+				sprintf(extra + strlen(extra), "\nStart continuous DA=ffffffffffff len=1500\n infinite=yes.");
 			else
-				sprintf(extra, "%s\nSpecify carrier suppression but not CCK rate", extra);
+				sprintf(extra + strlen(extra), "\nSpecify carrier suppression but not CCK rate");
 		}
 		SetCarrierSuppressionTx(padapter, (u8)bStartTest);
 		break;
 	case MP_SINGLE_CARRIER_TX:
 		if (bStartTest != 0)
-			sprintf(extra, "%s\nStart continuous DA=ffffffffffff len=1500\n infinite=yes.", extra);
+			sprintf(extra + strlen(extra), "\nStart continuous DA=ffffffffffff len=1500\n infinite=yes.");
 		SetSingleCarrierTx(padapter, (u8)bStartTest);
 		break;
 
@@ -1494,12 +1494,12 @@ int rtw_mp_tx(struct net_device *dev,
 	} else if (strncmp(extra, "setting", 7) == 0) {
 		memset(extra, 0, wrqu->data.length);
 		sprintf(extra, "Current Setting :\n Channel:%d", pmp_priv->channel);
-		sprintf(extra, "%s\n Bandwidth:%d", extra, pmp_priv->bandwidth);
-		sprintf(extra, "%s\n Rate index:%d", extra, pmp_priv->rateidx);
-		sprintf(extra, "%s\n TxPower index:%d", extra, pmp_priv->txpoweridx);
-		sprintf(extra, "%s\n Antenna TxPath:%d", extra, pmp_priv->antenna_tx);
-		sprintf(extra, "%s\n Antenna RxPath:%d", extra, pmp_priv->antenna_rx);
-		sprintf(extra, "%s\n MP Mode:%d", extra, pmp_priv->mode);
+		sprintf(extra + strlen(extra), "\n Bandwidth:%d", pmp_priv->bandwidth);
+		sprintf(extra + strlen(extra), "\n Rate index:%d", pmp_priv->rateidx);
+		sprintf(extra + strlen(extra), "\n TxPower index:%d", pmp_priv->txpoweridx);
+		sprintf(extra + strlen(extra), "\n Antenna TxPath:%d", pmp_priv->antenna_tx);
+		sprintf(extra + strlen(extra), "\n Antenna RxPath:%d", pmp_priv->antenna_rx);
+		sprintf(extra + strlen(extra), "\n MP Mode:%d", pmp_priv->mode);
 		wrqu->data.length = strlen(extra);
 		return 0;
 #ifdef CONFIG_MP_VHT_HW_TX_MODE
@@ -1638,17 +1638,17 @@ int rtw_mp_tx(struct net_device *dev,
 			RTW_INFO("Invalid format [ch=%d,bw=%d,rate=%d,pwr=%d,ant=%d,tx=%d]\n", channel, bandwidth, rate, txpower, ant, txmode);
 			memset(extra, 0, wrqu->data.length);
 			sprintf(extra, "\n Please input correct format as bleow:\n");
-			sprintf(extra, "%s\t ch=%d,bw=%d,rate=%d,pwr=%d,ant=%d,tx=%d\n", extra, channel, bandwidth, rate, txpower, ant, txmode);
-			sprintf(extra, "%s\n [ ch : BGN = <1~14> , A or AC = <36~165> ]", extra);
-			sprintf(extra, "%s\n [ bw : Bandwidth: 0 = 20M, 1 = 40M, 2 = 80M ]", extra);
-			sprintf(extra, "%s\n [ rate :	CCK: 1 2 5.5 11M X 2 = < 2 4 11 22 >]", extra);
-			sprintf(extra, "%s\n [		OFDM: 6 9 12 18 24 36 48 54M X 2 = < 12 18 24 36 48 72 96 108>", extra);
-			sprintf(extra, "%s\n [		HT 1S2SS MCS0 ~ MCS15 : < [MCS0]=128 ~ [MCS7]=135 ~ [MCS15]=143 >", extra);
-			sprintf(extra, "%s\n [		HT 3SS MCS16 ~ MCS32 : < [MCS16]=144 ~ [MCS23]=151 ~ [MCS32]=159 >", extra);
-			sprintf(extra, "%s\n [		VHT 1SS MCS0 ~ MCS9 : < [MCS0]=160 ~ [MCS9]=169 >", extra);
-			sprintf(extra, "%s\n [ txpower : 1~63 power index", extra);
-			sprintf(extra, "%s\n [ ant : <A = 1, B = 2, C = 4, D = 8> ,2T ex: AB=3 BC=6 CD=12", extra);
-			sprintf(extra, "%s\n [ txmode : < 0 = CONTINUOUS_TX, 1 = PACKET_TX, 2 = SINGLE_TONE_TX, 3 = CARRIER_SUPPRISSION_TX, 4 = SINGLE_CARRIER_TX>\n", extra);
+			sprintf(extra + strlen(extra), "\t ch=%d,bw=%d,rate=%d,pwr=%d,ant=%d,tx=%d\n", channel, bandwidth, rate, txpower, ant, txmode);
+			sprintf(extra + strlen(extra), "\n [ ch : BGN = <1~14> , A or AC = <36~165> ]");
+			sprintf(extra + strlen(extra), "\n [ bw : Bandwidth: 0 = 20M, 1 = 40M, 2 = 80M ]");
+			sprintf(extra + strlen(extra), "\n [ rate :	CCK: 1 2 5.5 11M X 2 = < 2 4 11 22 >]");
+			sprintf(extra + strlen(extra), "\n [		OFDM: 6 9 12 18 24 36 48 54M X 2 = < 12 18 24 36 48 72 96 108>");
+			sprintf(extra + strlen(extra), "\n [		HT 1S2SS MCS0 ~ MCS15 : < [MCS0]=128 ~ [MCS7]=135 ~ [MCS15]=143 >");
+			sprintf(extra + strlen(extra), "\n [		HT 3SS MCS16 ~ MCS32 : < [MCS16]=144 ~ [MCS23]=151 ~ [MCS32]=159 >");
+			sprintf(extra + strlen(extra), "\n [		VHT 1SS MCS0 ~ MCS9 : < [MCS0]=160 ~ [MCS9]=169 >");
+			sprintf(extra + strlen(extra), "\n [ txpower : 1~63 power index");
+			sprintf(extra + strlen(extra), "\n [ ant : <A = 1, B = 2, C = 4, D = 8> ,2T ex: AB=3 BC=6 CD=12");
+			sprintf(extra + strlen(extra), "\n [ txmode : < 0 = CONTINUOUS_TX, 1 = PACKET_TX, 2 = SINGLE_TONE_TX, 3 = CARRIER_SUPPRISSION_TX, 4 = SINGLE_CARRIER_TX>\n");
 			wrqu->data.length = strlen(extra);
 			return status;
 
@@ -1664,13 +1664,13 @@ int rtw_mp_tx(struct net_device *dev,
 				bandwidth = CHANNEL_WIDTH_40;
 			else if (bandwidth == 2)
 				bandwidth = CHANNEL_WIDTH_80;
-			sprintf(extra, "%s\nChange Current Bandwidth %d to Bandwidth %d", extra, padapter->mppriv.bandwidth , bandwidth);
+			sprintf(extra + strlen(extra), "\nChange Current Bandwidth %d to Bandwidth %d", padapter->mppriv.bandwidth , bandwidth);
 			padapter->mppriv.bandwidth = (u8)bandwidth;
 			padapter->mppriv.preamble = sg;
 			SetBandwidth(padapter);
 			pHalData->current_channel_bw = bandwidth;
 
-			sprintf(extra, "%s\nSet power level :%d", extra, txpower);
+			sprintf(extra + strlen(extra), "\nSet power level :%d", txpower);
 			padapter->mppriv.txpoweridx = (u8)txpower;
 			pMptCtx->TxPwrLevel[ODM_RF_PATH_A] = (u8)txpower;
 			pMptCtx->TxPwrLevel[ODM_RF_PATH_B] = (u8)txpower;
@@ -1693,13 +1693,13 @@ int rtw_mp_tx(struct net_device *dev,
 			RTW_INFO("%s: rate index=%d\n", __func__, rate);
 			if (rate >= MPT_RATE_LAST)
 				return -EINVAL;
-			sprintf(extra, "%s\nSet data rate to %d index %d", extra, padapter->mppriv.rateidx, rate);
+			sprintf(extra + strlen(extra), "\nSet data rate to %d index %d", padapter->mppriv.rateidx, rate);
 
 			padapter->mppriv.rateidx = rate;
 			pMptCtx->mpt_rate_index = rate;
 			SetDataRate(padapter);
 
-			sprintf(extra, "%s\nSet Antenna Path :%d",  extra, ant);
+			sprintf(extra + strlen(extra), "\nSet Antenna Path :%d", ant);
 			switch (ant) {
 			case 1:
 				antenna = ANTENNA_A;
@@ -1808,10 +1808,10 @@ int rtw_mp_rx(struct net_device *dev,
 		RTW_INFO("Invalid format [ch=%d,bw=%d,ant=%d]\n", channel, bandwidth, ant);
 		memset(extra, 0, wrqu->data.length);
 		sprintf(extra, "\n Please input correct format as bleow:\n");
-		sprintf(extra, "%s\t ch=%d,bw=%d,ant=%d\n", extra, channel, bandwidth, ant);
-		sprintf(extra, "%s\n [ ch : BGN = <1~14> , A or AC = <36~165> ]", extra);
-		sprintf(extra, "%s\n [ bw : Bandwidth: 0 = 20M, 1 = 40M, 2 = 80M ]", extra);
-		sprintf(extra, "%s\n [ ant : <A = 1, B = 2, C = 4, D = 8> ,2T ex: AB=3 BC=6 CD=12", extra);
+		sprintf(extra + strlen(extra), "\t ch=%d,bw=%d,ant=%d\n", channel, bandwidth, ant);
+		sprintf(extra + strlen(extra), "\n [ ch : BGN = <1~14> , A or AC = <36~165> ]");
+		sprintf(extra + strlen(extra), "\n [ bw : Bandwidth: 0 = 20M, 1 = 40M, 2 = 80M ]");
+		sprintf(extra + strlen(extra), "\n [ ant : <A = 1, B = 2, C = 4, D = 8> ,2T ex: AB=3 BC=6 CD=12");
 		wrqu->data.length = strlen(extra);
 		return 0;
 
@@ -1828,13 +1828,13 @@ int rtw_mp_rx(struct net_device *dev,
 			bandwidth = CHANNEL_WIDTH_40;
 		else if (bandwidth == 2)
 			bandwidth = CHANNEL_WIDTH_80;
-		sprintf(extra, "%s\nChange Current Bandwidth %d to Bandwidth %d", extra, padapter->mppriv.bandwidth , bandwidth);
+		sprintf(extra + strlen(extra), "\nChange Current Bandwidth %d to Bandwidth %d", padapter->mppriv.bandwidth , bandwidth);
 		padapter->mppriv.bandwidth = (u8)bandwidth;
 		padapter->mppriv.preamble = sg;
 		SetBandwidth(padapter);
 		pHalData->current_channel_bw = bandwidth;
 
-		sprintf(extra, "%s\nSet Antenna Path :%d",  extra, ant);
+		sprintf(extra + strlen(extra), "\nSet Antenna Path :%d", ant);
 		switch (ant) {
 		case 1:
 			antenna = ANTENNA_A;
@@ -1885,7 +1885,7 @@ int rtw_mp_rx(struct net_device *dev,
 		pHalData->antenna_tx_path = antenna;
 		SetAntenna(padapter);
 
-		sprintf(extra, "%s\nstart Rx", extra);
+		sprintf(extra + strlen(extra), "\nstart Rx");
 		SetPacketRx(padapter, bStartRx, false);
 	}
 	wrqu->data.length = strlen(extra);
@@ -1962,11 +1962,11 @@ int rtw_efuse_mask_file(struct net_device *dev,
 		 } while (count < 64);
 
 		for (i = 0; i < count; i++)
-			sprintf(extra, "%s:%02x", extra, maskfileBuffer[i]);
+			sprintf(extra + strlen(extra), ":%02x", maskfileBuffer[i]);
 
 		padapter->registrypriv.bFileMaskEfuse = true;
 
-		sprintf(extra, "%s\nLoad Efuse Mask data %d hex ok\n", extra, count);
+		sprintf(extra + strlen(extra), "\nLoad Efuse Mask data %d hex ok\n", count);
 		wrqu->data.length = strlen(extra);
 		return 0;
 	}


### PR DESCRIPTION
Compiling the 5.2.2.4 driver with GCC 10.1.0 gives a lot of warnings like this:
```
/var/lib/dkms/8188eu/5.2.2.4.r767.33dbf80/build/os_dep/ioctl_linux.c: In function ‘rtw_mp_efuse_get’:
/var/lib/dkms/8188eu/5.2.2.4.r767.33dbf80/build/os_dep/ioctl_linux.c:8784:4: warning: ‘sprintf’ argument 3 overlaps destination object ‘extra’ [-Wrestrict]
 8784 |    sprintf(extra, "%s0x%02X\n", extra, mask_buf[i]);
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/var/lib/dkms/8188eu/5.2.2.4.r767.33dbf80/build/os_dep/ioctl_linux.c:8205:39: note: destination object referenced by ‘restrict’-qualified argument 1 was declared here
 8205 |        union iwreq_data *wdata, char *extra)
      |                                 ~~~~~~^~~~~
```
This warning tells us that buffers passed to sprintf should not overlap, so I changed every occurence of
`sprintf(str, "%sABC", str)`
to
`sprintf(str + strlen(str), "ABC")`
which is functionally equivalent, but avoids the overlapping issue.