### PR TITLE
rtl8188eu: Allow use of KERNEL_SRC variable when defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc.*/powerpc/; s/armv.l/a
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
 KVER  ?= $(if $(KERNELRELEASE),$(KERNELRELEASE),$(shell uname -r))
-KSRC ?= /lib/modules/$(KVER)/build
+KSRC ?= $(if $(KERNEL_SRC),$(KERNEL_SRC),/lib/modules/$(KVER)/build)
 MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless
 INSTALL_PREFIX :=
 


### PR DESCRIPTION
By this way I can compile this module
in both environment (KERNEL_SRC / KSRC)

Signed-off-by: Matteo Facchinetti <matteo.facchinetti@sirius-es.it>