### PR TITLE
Add support for Edimax EW-7811Un V2

### DIFF
--- a/os_dep/usb_intf.c
+++ b/os_dep/usb_intf.c
@@ -63,6 +63,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x2357, 0x0111)}, /* TP-Link TL-WN727N v5.21 */
 	{USB_DEVICE(0x2C4E, 0x0102)}, /* MERCUSYS MW150US v2 */
 	{USB_DEVICE(0x0B05, 0x18F0)}, /* ASUS USB-N10 Nano B1 */
+	{USB_DEVICE(0x7392, 0xb811)}, /* Edimax EW-7811Un V2 */
 	{}	/* Terminating entry */
 };
 


### PR DESCRIPTION
The following PR adds support for the *Edimax EW-7811Un V2* usb wifi dongle.

I have successfully tested this and it works as expected; only the IDs are missing.