### PR TITLE
Update Makefile to not error if repo was cloned using Sapling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ endif
 all: test modules
 
 test:
-	@if [ !  -e  ./.git ] ; then echo $(MSG); exit 1; fi;
+	@if [ !  -e  ./.git  -a  !  -e  ./.sl ] ; then echo $(MSG); exit 1; fi;
 
 modules:
 	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules


### PR DESCRIPTION
This changes the `test` Makefile target conditional to pass for Sapling cloned repos.

I was building this locally and got the error message about zip files because I cloned the repo using Sapling (https://sapling-scm.com) which uses a `.sl` directory at the repo root as opposed to a `.git` directory. Getting around the message was just making an empty top level `.git` directory, but IMO it shouldn't show this error in this case.

As of now, this would also fail with for Mercurial cloned repos (which uses a `.hg` directory). I thought of generalizing it to check for any hidden top level directory, but technically `.git` can be a can be a text file (see: https://git-scm.com/docs/gitrepository-layout), so didn't go that route.

Also, I opted to not change the message printed in the failure case to mention Sapling or .sl as it might cause more confusion than benefit.