### PR TITLE
Fix connection issue with some router.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ CONFIG_POWER_SAVING = y
 CONFIG_EFUSE_CONFIG_FILE = y
 CONFIG_TRAFFIC_PROTECT = y
 CONFIG_LOAD_PHY_PARA_FROM_FILE = y
+CONFIG_TXPWR_BY_RATE_EN = n
+CONFIG_TXPWR_LIMIT_EN = n
 CONFIG_RTW_ADAPTIVITY_EN = disable
 CONFIG_RTW_ADAPTIVITY_MODE = normal
 CONFIG_BR_EXT = y
@@ -80,7 +82,7 @@ _HAL_INTFS_FILES :=	hal_intf.o \
 			hal_usb.o \
 			hal_usb_led.o
 
-			
+
 _OUTSRC_FILES := phydm_debug.o	\
 		phydm_antdiv.o\
 		phydm_antdect.o\
@@ -389,7 +391,7 @@ rtk_core :=	rtw_cmd.o \
 		rtw_btcoex.o \
 		rtw_beamforming.o \
 		rtw_odm.o \
-		rtw_efuse.o 
+		rtw_efuse.o
 
 8188eu-y += $(rtk_core)
 


### PR DESCRIPTION
Commit 99a65acdfc87dbb3a4b90de8c01a0ec8fcd7eefa introduced a bug that the default value of `CONFIG_TXPWR_BY_RATE_EN` and `CONFIG_TXPWR_LIMIT_EN` are changed, in result the chip will use Tx power adjustment defined by efuse instead of disabled.

Which cause the chip unable to connect to some routers like Teltonika. (efuse not correctly burned ?) The symptome is many association attempt, even once connected many retransmission can be seen by Wireshark capture. 


![image](https://github.com/user-attachments/assets/2f50c00b-77d6-4dd0-932e-f8d36e8f7279)

---
RIP Larry 🙏